### PR TITLE
ci: fix main integration-test workflow selector

### DIFF
--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -46,4 +46,4 @@ jobs:
       run: bun run test
 
     - name: Integration tests (generator)
-      run: bun run test -- tests/integration/**/*.test.ts
+      run: bunx vitest run tests/integration

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Transform your OpenAPI 3.0+ specifications into production-ready TypeScript clie
 [![npm version](https://img.shields.io/npm/v/@azwebmaster/openapi-to-ts.svg)](https://www.npmjs.com/package/@azwebmaster/openapi-to-ts)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## ✨ Why This Generator?
+## Features
 
 - **🎯 Zero Config**: Works out of the box with any OpenAPI 3.0+ spec
 - **🔒 Type Safe**: Full TypeScript support with discriminated unions, nullable types, and schema composition
@@ -17,7 +17,7 @@ Transform your OpenAPI 3.0+ specifications into production-ready TypeScript clie
 
 ## 🚀 Quick Start
 
-### Install
+## Installation
 
 ```bash
 # For CLI usage (recommended)


### PR DESCRIPTION
Fixes the failing main workflow integration-test step.

## Root cause
`bun run test -- tests/integration/**/*.test.ts` resolves to a Vitest filter that does not reliably match in GitHub Actions, causing:
`No test files found, exiting with code 1`.

## Changes
- `.github/workflows/shared-ci.yml`
  - `bun run test -- tests/integration/**/*.test.ts`
  - → `bunx vitest run tests/integration`
- `README.md`
  - add required headings expected by docs validation (`Features`, `Installation`)

## Validation
- `bun run build`
- `bun run test`
- `bunx vitest run tests/integration`
