### PR TITLE
docs: improve README accuracy, CLI references, and contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ bun run test
 
 Run tests in watch mode:
 ```bash
-bun run test --watch
+bun run test:watch
 ```
 
 ### Building
@@ -55,10 +55,21 @@ Test the CLI locally:
 # Build first
 bun run build
 
-# Test CLI commands
+# Test CLI commands (also available as `ott`)
 bun run cli generate path/to/spec.yaml
 bun run cli info path/to/spec.yaml
+bun run cli init path/to/spec.yaml
+bun run cli list
 bun run cli examples
+```
+
+### Sample Specs
+
+The `samples/` directory contains OpenAPI v3 and Swagger v2 specs at varying complexity levels. Use these for manual testing and as reference when updating documentation:
+
+```bash
+cd samples/openapi-v3-simple
+./generate.sh
 ```
 
 ### Code Quality
@@ -72,13 +83,17 @@ This project uses:
 
 ```
 src/
-├── cli.ts          # Command-line interface
-├── generator.ts    # Core generation logic
-├── index.ts        # Main exports
-└── ...
+├── cli.ts              # Command-line interface
+├── generator.ts        # Core generation logic
+├── index.ts            # Main exports
+├── types.ts            # Shared types and enums
+├── utils/              # Naming, JSDoc, and progress helpers
+└── *.test.ts           # Test files
 
-dist/               # Compiled output
-.github/workflows/  # CI/CD workflows
+samples/                # OpenAPI v3 and Swagger v2 sample specs
+tests/                  # Integration tests
+dist/                   # Compiled output
+.github/workflows/      # CI/CD workflows
 ```
 
 ## Contributing Guidelines
@@ -116,14 +131,19 @@ bun run test
 bun run build
 ```
 
-5. Update documentation if needed
+5. Update documentation if needed (README, samples README, or inline JSDoc)
 
-6. Commit your changes:
+6. Add a changeset when your change should trigger a release:
+```bash
+bun run changeset
+```
+
+7. Commit your changes:
 ```bash
 git commit -m "feat: add your feature description"
 ```
 
-7. Push to your fork and create a pull request
+8. Push to your fork and create a pull request
 
 ### Commit Message Format
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Transform your OpenAPI 3.0+ specifications into production-ready TypeScript clie
 
 ## Features
 
-- **🎯 Zero Config**: Works out of the box with any OpenAPI 3.0+ spec
+- **🎯 Zero Config**: Works out of the box with any OpenAPI 3.0+ or Swagger 2.0 spec
 - **🔒 Type Safe**: Full TypeScript support with discriminated unions, nullable types, and schema composition
 - **⚡ Fast**: Built with ts-morph for lightning-fast code generation
 - **🛠️ Developer Friendly**: Rich JSDoc comments, IntelliSense, and error-free generated code
@@ -17,7 +17,7 @@ Transform your OpenAPI 3.0+ specifications into production-ready TypeScript clie
 
 ## 🚀 Quick Start
 
-## Installation
+### Installation
 
 ```bash
 # For CLI usage (recommended)
@@ -34,7 +34,13 @@ bun add @azwebmaster/openapi-to-ts
 
 ### CLI Usage (Recommended)
 
-The CLI is the easiest way to generate TypeScript clients:
+The CLI is available as `openapi-to-ts` or the shorter alias `ott`:
+
+```bash
+openapi-to-ts generate ./api.yaml
+# or
+ott generate ./api.yaml
+```
 
 ```bash
 # Basic generation
@@ -64,7 +70,7 @@ For integration into build scripts or custom tooling:
 import { generateFromSpec } from '@azwebmaster/openapi-to-ts';
 
 await generateFromSpec({
-  inputSpec: './api.yaml',
+  spec: './api.yaml',
   outputDir: './generated/api',
   namespace: 'MyAPI',
   typeOutputMode: 'single-file'
@@ -94,30 +100,33 @@ const newUser = await api.createUser({
 
 ```
 generated/
-├── types.ts      # All TypeScript interfaces
-├── client.ts     # Axios-based API client
-└── index.ts      # Exports and factory function
+├── types.ts          # All TypeScript types (or re-exports when using file-per-type / group-by-tag)
+├── types/            # Individual type files (file-per-type or group-by-tag modes only)
+├── client.ts         # Axios-based API client class
+├── namespaces/       # Namespace modules (when operationIds use dot notation, e.g. users.getProfile)
+└── index.ts          # Exports and createClient factory
 ```
+
+See the [samples directory](samples/README.md) for working examples across OpenAPI v3 and Swagger v2 specs.
 
 ### Example Generated Types
 
 ```typescript
 // types.ts
-export interface User {
+export type User = {
   id: string;
   email: string;
   name: string;
   avatar?: string | null;
   preferences?: UserPreferences;
-}
+};
 
-export interface CreateUserRequest {
+export type CreateUserRequest = {
   email: string;
   name: string;
   password: string;
   age?: number;
-}
-```
+};
 
 ### Example Generated Client
 
@@ -139,27 +148,6 @@ export class MyAPIClient {
 ```
 
 ## 🎯 Advanced Features
-
-### Configuration File System
-
-For complex projects, use `.ott.json` configuration files to manage multiple APIs and operation filtering:
-
-```bash
-# Initialize configuration from OpenAPI spec
-openapi-to-ts init ./api.yaml
-
-# List available operations
-openapi-to-ts list
-
-# Generate only selected operations
-openapi-to-ts generate --config --operation-ids "getUsers,createUser"
-```
-
-Configuration files support:
-- **Multiple APIs**: Generate clients for different OpenAPI specs
-- **Operation Filtering**: Select only the operations you need
-- **Persistent Settings**: Save generation options for team collaboration
-- **CI/CD Integration**: Use config files in automated builds
 
 ### Schema Composition Support
 
@@ -185,10 +173,10 @@ components:
 // Generated TypeScript
 export type Pet = Dog | Cat;
 
-export interface Dog extends BasePet {
+export type Dog = BasePet & {
   petType: "dog";
   breed: string;
-}
+};
 
 // TypeScript narrows the type automatically! 🎉
 pets.forEach(pet => {
@@ -213,15 +201,16 @@ vehicle: Car | Truck | Motorcycle;
 
 ### Namespace Organization
 
+When operationIds use dot notation (e.g. `users.getProfile`, `admin.getSystemStats`), the generator creates namespace properties on the client:
+
 ```typescript
-// Organized by operationId namespaces
 const api = createClient('https://api.example.com');
 
-// Direct methods
+// Flat operationIds (e.g. getUsers, createUser)
 await api.getUsers();
 await api.createUser(data);
 
-// Namespaced methods
+// Dot-separated operationIds become namespaces
 await api.users.getProfile();
 await api.users.updateSettings(data);
 await api.admin.getSystemStats();
@@ -229,7 +218,7 @@ await api.admin.getSystemStats();
 
 ## ⚙️ Configuration File System
 
-For complex projects or when you need to generate multiple API clients, use the configuration file system with `.ott.json`:
+For complex projects or when you need to generate multiple API clients, use `.ott.json` configuration files. The CLI auto-detects `.ott.json` in the current directory — you do not need a `--config` flag unless using a custom path.
 
 ### Initialize Configuration
 
@@ -280,11 +269,14 @@ openapi-to-ts list
 # List operations for specific API (if multiple APIs)
 openapi-to-ts list --api "My API"
 
-# Generate using configuration file
-openapi-to-ts generate --config
+# Generate using configuration file (auto-detects .ott.json in cwd)
+openapi-to-ts generate
 
 # Generate specific operations from CLI
-openapi-to-ts generate --config --operation-ids "getUsers,createUser"
+openapi-to-ts generate --operation-ids "getUsers,createUser"
+
+# Generate a specific API when multiple are defined in config
+openapi-to-ts generate --api "My API"
 ```
 
 ### Benefits of Configuration Files
@@ -325,7 +317,26 @@ openapi-to-ts examples
 | `-a, --axios-instance <name>` | Name for the Axios instance variable | `apiClient` |
 | `-t, --type-output <mode>` | Type organization: `single-file`, `file-per-type`, `group-by-tag` | `single-file` |
 | `-H, --header <header>` | Add header for URL requests (format: "Name: Value") | - |
+| `-c, --config <file>` | Path to configuration file | `.ott.json` in cwd |
+| `--api <name>` | Generate a specific API from a multi-API config | - |
+| `--operation-ids <ids>` | Comma-separated operation IDs to include | all |
 | `--dry-run` | Preview generation without writing files | `false` |
+| `--no-progress` | Disable progress messages | `false` |
+
+### Init Command Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-o, --output <dir>` | Default output directory for generated files | `./generated` |
+| `-c, --config <file>` | Path for the configuration file to create | `.ott.json` in cwd |
+| `-H, --header <header>` | Add header for URL requests (format: "Name: Value") | - |
+
+### List Command Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-c, --config <file>` | Path to configuration file | `.ott.json` in cwd |
+| `--api <name>` | List operations for a specific API in a multi-API config | - |
 
 ### CLI Examples
 
@@ -359,8 +370,8 @@ openapi-to-ts generate api.yaml --dry-run
 # Configuration file workflow
 openapi-to-ts init api.yaml                         # Create .ott.json config
 openapi-to-ts list                                  # List available operations
-openapi-to-ts generate --config                     # Generate using config
-openapi-to-ts generate --config --operation-ids "getUsers,createUser"  # Generate specific operations
+openapi-to-ts generate                              # Generate using auto-detected .ott.json
+openapi-to-ts generate --operation-ids "getUsers,createUser"  # Generate specific operations
 
 # Show API specification information
 openapi-to-ts info api.yaml
@@ -432,12 +443,19 @@ Environment variables also work in `.ott.json` configuration files:
 - **`file-per-type`**: Each type in its own file under `types/` directory
 - **`group-by-tag`**: Types grouped by OpenAPI tags/categories
 
+### Client Output Modes
+
+Client output mode is configured programmatically via `clientOutputMode` (not available as a CLI flag):
+
+- **`split-by-namespace`** (default): Groups dot-separated operationIds into namespace modules under `namespaces/`
+- **`single-file`**: All client methods in a single `client.ts` file
+
 ## 🔧 Programmatic Usage
 
 For integration into build scripts, CI/CD pipelines, or custom tooling:
 
 ```typescript
-import { generateFromSpec, TypeOutputMode } from '@azwebmaster/openapi-to-ts';
+import { generateFromSpec, TypeOutputMode, ClientOutputMode } from '@azwebmaster/openapi-to-ts';
 
 // Basic usage
 await generateFromSpec({
@@ -453,11 +471,13 @@ await generateFromSpec({
   namespace: 'GitHubAPI',
   axiosInstanceName: 'githubClient',
   typeOutputMode: TypeOutputMode.FilePerType,
+  clientOutputMode: ClientOutputMode.SplitByNamespace,
   headers: {
     'Authorization': 'Bearer ${API_TOKEN}',
     'X-API-Key': '${API_KEY:default-key}'
   },
-  operationIds: ['getUsers', 'createUser', 'updateUser']
+  operationIds: ['getUsers', 'createUser', 'updateUser'],
+  noProgress: true
 });
 ```
 
@@ -471,7 +491,9 @@ interface GeneratorOptions {
   axiosInstanceName?: string;           // Name for Axios instance (default: 'apiClient')
   headers?: Record<string, string>;     // HTTP headers for remote specs
   typeOutputMode?: TypeOutputMode;      // How to organize generated types
-  operationIds?: string[];              // Filter specific operations to generate
+  clientOutputMode?: ClientOutputMode;  // How to organize client methods (default: split-by-namespace)
+  operationIds?: string[];            // Filter specific operations to generate
+  noProgress?: boolean;                 // Disable progress messages (default: false)
 }
 
 enum TypeOutputMode {
@@ -479,13 +501,18 @@ enum TypeOutputMode {
   FilePerType = 'file-per-type',        // One file per type
   GroupByTag = 'group-by-tag'           // Group by OpenAPI tags
 }
+
+enum ClientOutputMode {
+  SingleFile = 'single-file',           // All methods in one client file
+  SplitByNamespace = 'split-by-namespace' // Namespace modules for dot-separated operationIds
+}
 ```
 
 ### Build Script Integration
 
 ```typescript
 // scripts/generate-api.ts
-import { generateFromSpec, TypeOutputMode } from '@azwebmaster/openapi-to-ts';
+import { generateFromSpec, TypeOutputMode, ClientOutputMode } from '@azwebmaster/openapi-to-ts';
 
 async function generateAPI() {
   try {

--- a/samples/README.md
+++ b/samples/README.md
@@ -103,19 +103,16 @@ Each sample directory contains:
 
 ### Basic Usage
 ```typescript
-import { createAPIClient } from './generated';
+import { createClient } from './generated';
 
-const client = createAPIClient({
-  baseURL: 'https://api.example.com/v1'
-});
+const client = createClient('https://api.example.com/v1');
 
 const users = await client.getUsers();
 ```
 
 ### With Authentication
 ```typescript
-const client = createAPIClient({
-  baseURL: 'https://api.example.com/v1',
+const client = createClient('https://api.example.com/v1', {
   headers: {
     'Authorization': 'Bearer your-token',
     'X-API-Key': 'your-api-key'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,7 +86,7 @@ program
 
       console.log('Next steps:');
       console.log('1. Edit the operationIds array in .ott.json to select which operations to generate');
-      console.log('2. Run: openapi-gen generate --config to generate the client');
+      console.log('2. Run: openapi-to-ts generate to generate the client');
 
     } catch (error: any) {
       console.error('\n❌ Failed to initialize configuration:');
@@ -111,20 +111,20 @@ program
       const config = await OpenAPIGenerator.loadConfig(options.config);
       if (!config) {
         console.error(`❌ Error: Configuration file not found: ${options.config}`);
-        console.error('   Run "openapi-gen init <spec>" to create a configuration file first.');
+        console.error('   Run "openapi-to-ts init <spec>" to create a configuration file first.');
         process.exit(1);
       }
 
       // Validate config structure
       if (!config.apis || !Array.isArray(config.apis)) {
         console.error(`❌ Error: Invalid configuration file format. Missing or invalid 'apis' array.`);
-        console.error('   Run "openapi-gen init <spec>" to create a new configuration file.');
+        console.error('   Run "openapi-to-ts init <spec>" to create a new configuration file.');
         process.exit(1);
       }
 
       if (config.apis.length === 0) {
         console.error(`❌ Error: No APIs found in configuration file.`);
-        console.error('   Run "openapi-gen init <spec>" to create a new configuration file.');
+        console.error('   Run "openapi-to-ts init <spec>" to create a new configuration file.');
         process.exit(1);
       }
 
@@ -234,20 +234,20 @@ program
         const config = await OpenAPIGenerator.loadConfig(configPath);
         if (!config) {
           console.error(`❌ Error: Configuration file not found: ${configPath}`);
-          console.error('   Run "openapi-gen init <spec>" to create a configuration file first.');
+          console.error('   Run "openapi-to-ts init <spec>" to create a configuration file first.');
           process.exit(1);
         }
 
         // Validate config structure
         if (!config.apis || !Array.isArray(config.apis)) {
           console.error(`❌ Error: Invalid configuration file format. Missing or invalid 'apis' array.`);
-          console.error('   Run "openapi-gen init <spec>" to create a new configuration file.');
+          console.error('   Run "openapi-to-ts init <spec>" to create a new configuration file.');
           process.exit(1);
         }
 
         if (config.apis.length === 0) {
           console.error(`❌ Error: No APIs found in configuration file.`);
-          console.error('   Run "openapi-gen init <spec>" to create a new configuration file.');
+          console.error('   Run "openapi-to-ts init <spec>" to create a new configuration file.');
           process.exit(1);
         }
 
@@ -302,8 +302,8 @@ program
         // Traditional mode - validate spec
         if (!spec) {
           console.error('❌ Error: No spec provided and no configuration file found.');
-          console.error('   Use: openapi-gen generate <spec> or create a .ott.json configuration file');
-          console.error('   Run: openapi-gen init <spec> to create a configuration file');
+          console.error('   Use: openapi-to-ts generate <spec> or create a .ott.json configuration file');
+          console.error('   Run: openapi-to-ts init <spec> to create a configuration file');
           process.exit(1);
         }
 
@@ -353,8 +353,8 @@ program
         // Traditional mode - validate spec
         if (!spec) {
           console.error('❌ Error: No spec provided and no configuration file found.');
-          console.error('   Use: openapi-gen generate <spec> or create a .ott.json configuration file');
-          console.error('   Run: openapi-gen init <spec> to create a configuration file');
+          console.error('   Use: openapi-to-ts generate <spec> or create a .ott.json configuration file');
+          console.error('   Run: openapi-to-ts init <spec> to create a configuration file');
           process.exit(1);
         }
 
@@ -749,51 +749,51 @@ program
     console.log('=============================\n');
 
     console.log('🔧 Basic generation:');
-    console.log('   openapi-gen generate ./api.yaml\n');
+    console.log('   openapi-to-ts generate ./api.yaml\n');
 
     console.log('🌐 Generate from URL:');
-    console.log('   openapi-gen generate https://api.example.com/openapi.json\n');
+    console.log('   openapi-to-ts generate https://api.example.com/openapi.json\n');
 
     console.log('🔐 Generate from URL with authentication:');
-    console.log('   openapi-gen generate https://api.example.com/openapi.json \\');
+    console.log('   openapi-to-ts generate https://api.example.com/openapi.json \\');
     console.log('     -H "Authorization: Bearer your-token" \\');
     console.log('     -H "X-API-Key: your-api-key"\n');
 
     console.log('⚙️  Initialize configuration:');
-    console.log('   openapi-gen init ./api.yaml\n');
+    console.log('   openapi-to-ts init ./api.yaml\n');
 
     console.log('🔐 Initialize from URL with authentication:');
-    console.log('   openapi-gen init https://api.example.com/openapi.json \\');
+    console.log('   openapi-to-ts init https://api.example.com/openapi.json \\');
     console.log('     -H "Authorization: Bearer your-token" \\');
     console.log('     -H "X-API-Key: your-api-key"\n');
 
     console.log('🎯 Custom output directory:');
-    console.log('   openapi-gen generate ./api.yaml -o ./src/api\n');
+    console.log('   openapi-to-ts generate ./api.yaml -o ./src/api\n');
 
     console.log('🏷️  Custom namespace:');
-    console.log('   openapi-gen generate ./api.yaml -n MyAPI\n');
+    console.log('   openapi-to-ts generate ./api.yaml -n MyAPI\n');
 
     console.log('📦 Type output modes:');
     console.log('   # Single file (default):');
-    console.log('   openapi-gen generate ./api.yaml\n');
+    console.log('   openapi-to-ts generate ./api.yaml\n');
     console.log('   # One file per type:');
-    console.log('   openapi-gen generate ./api.yaml -t file-per-type\n');
+    console.log('   openapi-to-ts generate ./api.yaml -t file-per-type\n');
     console.log('   # Group by tag/category:');
-    console.log('   openapi-gen generate ./api.yaml -t group-by-tag\n');
+    console.log('   openapi-to-ts generate ./api.yaml -t group-by-tag\n');
 
     console.log('⚙️  All options:');
-    console.log('   openapi-gen generate ./api.yaml \\');
+    console.log('   openapi-to-ts generate ./api.yaml \\');
     console.log('     --output ./src/generated \\');
     console.log('     --namespace GitHubAPI \\');
     console.log('     --axios-instance githubClient \\');
     console.log('     --type-output file-per-type\n');
 
     console.log('🔍 Dry run (preview):');
-    console.log('   openapi-gen generate ./api.yaml --dry-run\n');
+    console.log('   openapi-to-ts generate ./api.yaml --dry-run\n');
 
     console.log('📋 Spec information:');
-    console.log('   openapi-gen info ./api.yaml');
-    console.log('   openapi-gen info https://api.example.com/openapi.json\n');
+    console.log('   openapi-to-ts info ./api.yaml');
+    console.log('   openapi-to-ts info https://api.example.com/openapi.json\n');
 
     console.log('💡 Tips:');
     console.log('   • Supports both YAML and JSON OpenAPI specs');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves project documentation for accuracy and completeness across the README, contributor guide, samples, and CLI user-facing messages.

## Changes

### README
- Fix incorrect `inputSpec` option in programmatic usage (should be `spec`)
- Document Swagger 2.0 support and the `ott` CLI alias
- Expand generated output structure to include `namespaces/` and `types/` directories
- Consolidate duplicate configuration file sections
- Clarify that `.ott.json` is auto-detected (no `--config` flag required)
- Document missing CLI flags: `--api`, `--config`, `--operation-ids`, `--no-progress`, and init/list command options
- Add `ClientOutputMode` and `noProgress` to programmatic API reference
- Update type examples to use `type` instead of `interface` (matching current generator output)
- Link to `samples/README.md` for working examples

### CONTRIBUTING.md
- Fix `test:watch` script name
- Expand project structure and sample testing guidance
- Document changeset workflow for releases

### samples/README.md
- Fix incorrect `createAPIClient` usage — generated clients use `createClient(baseURL, config?)`

### CLI
- Replace stale `openapi-gen` references with `openapi-to-ts` in help text, examples, and error messages
- Update `init` next-steps to use `openapi-to-ts generate` without unnecessary `--config` flag
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1b5f-6bde-7202-ab72-00e6b032b8bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1b5f-6bde-7202-ab72-00e6b032b8bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

