### PR TITLE
fix: correct generated client accessors, imports, and URL redirects

### DIFF
--- a/.changeset/fix-generator-bugs.md
+++ b/.changeset/fix-generator-bugs.md
@@ -1,0 +1,5 @@
+---
+"@azwebmaster/openapi-to-ts": patch
+---
+
+fix invalid accessors for hyphenated query/header params, missing main-client type/AxiosResponse imports, empty types.ts module exports, relative URL redirects, and const/discriminator escaping

--- a/src/generator.test.ts
+++ b/src/generator.test.ts
@@ -177,6 +177,23 @@ describe('OpenAPIGenerator', () => {
           const result = naming.toPropertyName('name with spaces');
           expect(result).toBe("'name with spaces'");
         });
+
+        it('should escape embedded single quotes', () => {
+          const result = naming.toPropertyName("O'Reilly");
+          expect(result).toBe("'O\\'Reilly'");
+        });
+      });
+
+      describe('toPropertyAccessor', () => {
+        it('should use dot notation for valid identifiers', () => {
+          expect(naming.toPropertyAccessor('params', 'userId')).toBe('params.userId');
+          expect(naming.toPropertyAccessor('params', 'userId', true)).toBe('params?.userId');
+        });
+
+        it('should use bracket notation for invalid identifiers', () => {
+          expect(naming.toPropertyAccessor('params', 'x-api-key')).toBe("params['x-api-key']");
+          expect(naming.toPropertyAccessor('params', 'sort-by', true)).toBe("params?.['sort-by']");
+        });
       });
 
       describe('toMethodName', () => {
@@ -922,12 +939,30 @@ describe('OpenAPIGenerator', () => {
         const result = generator.generateDiscriminatedUnion(schema, types);
         expect(result).toBe('Cat | Dog');
       });
+
+      it('should quote discriminator property names that are invalid identifiers', () => {
+        const schema = {
+          discriminator: {
+            propertyName: 'pet-type',
+            mapping: {
+              'cat-a': '#/components/schemas/Cat'
+            }
+          }
+        };
+        const result = generator.generateDiscriminatedUnion(schema, ['Cat']);
+        expect(result).toBe('(Cat & { \'pet-type\': "cat-a" })');
+      });
     });
 
     describe('handleConst', () => {
       it('should handle string const', () => {
         const result = generator.handleConst({ const: 'fixed' });
         expect(result).toBe('"fixed"');
+      });
+
+      it('should escape quotes inside string const values', () => {
+        const result = generator.handleConst({ const: 'say "hi"' });
+        expect(result).toBe('"say \\"hi\\""');
       });
 
       it('should handle number const', () => {
@@ -3828,6 +3863,46 @@ describe('OpenAPIGenerator', () => {
       }
     });
 
+    it('should resolve relative redirect locations when fetching specs', async () => {
+      const http = await import('http');
+      const mockSpec = {
+        openapi: '3.0.0',
+        info: { title: 'Redirect API', version: '1.0.0' },
+        paths: {}
+      };
+
+      const server = http.createServer((req, res) => {
+        if (req.url === '/openapi.json') {
+          res.writeHead(302, { Location: '/v1/openapi.json' });
+          res.end();
+          return;
+        }
+        if (req.url === '/v1/openapi.json') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(mockSpec));
+          return;
+        }
+        res.writeHead(404);
+        res.end();
+      });
+
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        throw new Error('Failed to bind test server');
+      }
+
+      try {
+        const result = await generator.fetchFromUrl(`http://127.0.0.1:${address.port}/openapi.json`);
+        expect(result).toEqual(mockSpec);
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close(err => (err ? reject(err) : resolve()));
+        });
+      }
+    });
+
     it('should not leak event listeners', async () => {
       const initialListeners = process.listenerCount('uncaughtException') + 
                               process.listenerCount('unhandledRejection');
@@ -5054,6 +5129,181 @@ describe('import regression checks', () => {
     expect(content).toContain('BaseProfile');
     expect(content).toContain('ProfileDetails');
     expect(content).toMatch(/import type \{[^}]*BaseProfile[^}]*ProfileDetails[^}]*\} from "\.\.\/types\.js";|import type \{[^}]*ProfileDetails[^}]*BaseProfile[^}]*\} from "\.\.\/types\.js";/);
+  });
+
+  it('should import schema types and AxiosResponse for default-namespace methods on main client', async () => {
+    const testOutputDir = path.join(__dirname, 'test-output-main-client-imports');
+    try {
+      const specPath = path.join(testOutputDir, 'test-spec.yaml');
+      await fs.mkdir(testOutputDir, { recursive: true });
+      await fs.writeFile(
+        specPath,
+        JSON.stringify({
+          openapi: '3.0.0',
+          info: { title: 'Main Client Import API', version: '1.0.0' },
+          paths: {
+            '/users': {
+              get: {
+                operationId: 'listUsers',
+                responses: {
+                  '200': {
+                    description: 'OK',
+                    content: {
+                      'application/json': {
+                        schema: { $ref: '#/components/schemas/User' }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          components: {
+            schemas: {
+              User: {
+                type: 'object',
+                properties: { id: { type: 'string' } },
+                required: ['id']
+              }
+            }
+          }
+        }, null, 2)
+      );
+
+      const generator = new OpenAPIGenerator({
+        spec: specPath,
+        outputDir: testOutputDir,
+        namespace: 'MainClientImportAPI',
+      });
+      await generator.generate();
+
+      const clientContent = await fs.readFile(path.join(testOutputDir, 'client.ts'), 'utf-8');
+      expect(clientContent).toMatch(/AxiosResponse/);
+      expect(clientContent).toMatch(/import type \{[^}]*AxiosResponse[^}]*\} from "axios"/);
+      expect(clientContent).toMatch(/import type \{[^}]*User[^}]*\} from "\.\/types\.js"/);
+      expect(clientContent).toContain('Promise<AxiosResponse<User>>');
+    } finally {
+      await fs.rm(testOutputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should emit a valid empty module for types.ts when no schemas exist', async () => {
+    const testOutputDir = path.join(__dirname, 'test-output-empty-types');
+    try {
+      const specPath = path.join(testOutputDir, 'test-spec.yaml');
+      await fs.mkdir(testOutputDir, { recursive: true });
+      await fs.writeFile(
+        specPath,
+        JSON.stringify({
+          openapi: '3.0.0',
+          info: { title: 'Empty Types API', version: '1.0.0' },
+          paths: {
+            '/ping': {
+              get: {
+                operationId: 'ping',
+                responses: { '204': { description: 'No Content' } }
+              }
+            }
+          }
+        }, null, 2)
+      );
+
+      const generator = new OpenAPIGenerator({
+        spec: specPath,
+        outputDir: testOutputDir,
+        namespace: 'EmptyTypesAPI',
+      });
+      await generator.generate();
+
+      const typesContent = await fs.readFile(path.join(testOutputDir, 'types.ts'), 'utf-8');
+      expect(typesContent).toContain('export {};');
+    } finally {
+      await fs.rm(testOutputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should generate valid accessors for hyphenated query and header parameters', async () => {
+    const testOutputDir = path.join(__dirname, 'test-output-hyphenated-params');
+    try {
+      const specPath = path.join(testOutputDir, 'test-spec.yaml');
+      await fs.mkdir(testOutputDir, { recursive: true });
+      await fs.writeFile(
+        specPath,
+        JSON.stringify({
+          openapi: '3.0.0',
+          info: { title: 'Hyphen Params API', version: '1.0.0' },
+          paths: {
+            '/items': {
+              get: {
+                operationId: 'listItems',
+                parameters: [
+                  {
+                    name: 'x-api-key',
+                    in: 'header',
+                    required: true,
+                    schema: { type: 'string' }
+                  },
+                  {
+                    name: 'sort-by',
+                    in: 'query',
+                    schema: { type: 'string' }
+                  }
+                ],
+                responses: {
+                  '200': {
+                    description: 'OK',
+                    content: {
+                      'application/json': {
+                        schema: { type: 'object' }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }, null, 2)
+      );
+
+      const generator = new OpenAPIGenerator({
+        spec: specPath,
+        outputDir: testOutputDir,
+        namespace: 'HyphenParamsAPI',
+      });
+      await generator.generate();
+
+      const clientContent = await fs.readFile(path.join(testOutputDir, 'client.ts'), 'utf-8');
+      expect(clientContent).toContain("params['x-api-key']");
+      expect(clientContent).toContain("params?.['sort-by']");
+      expect(clientContent).not.toContain("params.'x-api-key'");
+      expect(clientContent).not.toContain("params?.'sort-by'");
+
+      // Ensure the full generated package type-checks (including empty schema sets)
+      const tsconfigPath = path.join(testOutputDir, 'tsconfig.test.json');
+      await fs.writeFile(
+        tsconfigPath,
+        JSON.stringify({
+          compilerOptions: {
+            target: 'ES2020',
+            module: 'ESNext',
+            moduleResolution: 'Node',
+            strict: true,
+            skipLibCheck: true,
+            noEmit: true,
+            types: ['node'],
+          },
+          include: ['**/*.ts'],
+        }, null, 2)
+      );
+
+      const tsc = spawnSync('bunx', ['tsc', '--noEmit', '-p', tsconfigPath], {
+        cwd: testOutputDir,
+        encoding: 'utf-8',
+      });
+      expect(tsc.status, `TypeScript check failed:\n${tsc.stdout}\n${tsc.stderr}`).toBe(0);
+    } finally {
+      await fs.rm(testOutputDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -111,7 +111,8 @@ export class OpenAPIGenerator {
     this.progress.message('✅ Generation complete!');
   }
 
-  public async fetchFromUrl(url: string, headers?: Record<string, string>): Promise<object> {
+  public async fetchFromUrl(url: string, headers?: Record<string, string>, redirectCount = 0): Promise<object> {
+    const maxRedirects = 10;
     return new Promise((resolve, reject) => {
       const client = url.startsWith('https://') ? https : http;
 
@@ -124,8 +125,13 @@ export class OpenAPIGenerator {
 
       const req = client.get(url, options, (res) => {
         if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-          // Handle redirects
-          this.fetchFromUrl(res.headers.location, headers).then(resolve).catch(reject);
+          if (redirectCount >= maxRedirects) {
+            reject(new Error(`Too many redirects while fetching OpenAPI spec from ${url}`));
+            return;
+          }
+          // Resolve relative redirect locations against the current URL
+          const redirectUrl = new URL(res.headers.location, url).href;
+          this.fetchFromUrl(redirectUrl, headers, redirectCount + 1).then(resolve).catch(reject);
           return;
         }
 
@@ -222,6 +228,12 @@ export class OpenAPIGenerator {
       this.generateTypeFromSchema(file, name, schema);
       this.progress.update(i + 1, this.naming.toTypeName(name));
     }
+
+    // Ensure types.ts is a valid ES module even when no schemas are generated,
+    // so index.ts can safely `export * from './types.js'`.
+    if (schemaEntries.length === 0) {
+      file.addStatements('export {};');
+    }
     
     this.progress.complete();
   }
@@ -313,6 +325,11 @@ export class OpenAPIGenerator {
       this.progress.update(i + 1, this.naming.toTypeName(name));
     }
 
+    // Ensure types.ts is a valid ES module even when no schemas are generated
+    if (schemaEntries.length === 0) {
+      indexFile.addStatements('export {};');
+    }
+
     this.progress.complete();
   }
 
@@ -398,6 +415,11 @@ export class OpenAPIGenerator {
       indexFile.addExportDeclaration({
         moduleSpecifier: `./types/${this.naming.toKebabCase(groupName)}.js`,
       });
+    }
+
+    // Ensure types.ts is a valid ES module even when no schemas are generated
+    if (totalTypes === 0) {
+      indexFile.addStatements('export {};');
     }
     
     this.progress.complete();
@@ -1040,6 +1062,7 @@ export class OpenAPIGenerator {
 
     // If discriminator has mapping, use mapped types
     if (discriminator.mapping) {
+      const propertyName = this.naming.toPropertyName(discriminator.propertyName);
       const mappedTypes = Object.entries(discriminator.mapping).map(([key, value]: [string, any]) => {
         let typeName: string;
         if (typeof value === 'string' && value.startsWith('#/')) {
@@ -1049,7 +1072,7 @@ export class OpenAPIGenerator {
         } else {
           typeName = this.naming.toTypeName(key);
         }
-        return `(${typeName} & { ${discriminator.propertyName}: "${key}" })`;
+        return `(${typeName} & { ${propertyName}: ${JSON.stringify(key)} })`;
       });
       return mappedTypes.join(' | ');
     }
@@ -1059,9 +1082,6 @@ export class OpenAPIGenerator {
 
   public handleConst(schema: any): string {
     if (schema.const !== undefined) {
-      if (typeof schema.const === 'string') {
-        return `"${schema.const}"`;
-      }
       return JSON.stringify(schema.const);
     }
     return 'unknown';
@@ -1225,6 +1245,9 @@ export class OpenAPIGenerator {
       }
     }
     
+    // Import schema types referenced by methods on the main client
+    this.addSchemaTypeImportsForClient(file, classDeclaration);
+
     if (totalOperations > 0) {
       this.progress.complete();
     }
@@ -1238,6 +1261,7 @@ export class OpenAPIGenerator {
       { overwrite: true }
     );
 
+    // AxiosResponse is added later if default-namespace methods are generated on this file
     mainFile.addImportDeclaration({
       moduleSpecifier: 'axios',
       namedImports: ['AxiosInstance', 'AxiosRequestConfig'],
@@ -1248,11 +1272,6 @@ export class OpenAPIGenerator {
       moduleSpecifier: 'axios',
       defaultImport: 'axios',
     });
-
-    // Note: Type imports for request/response types are not needed in client.ts
-    // as they are only used in namespace implementation files, not in the client class itself.
-    // The client only needs namespace operation interfaces and factory functions.
-    // We'll collect types per-namespace for optimal imports (optimization #1).
 
     const classDeclaration = mainFile.addClass({
       name: `${this.namespace}Client`,
@@ -1355,10 +1374,24 @@ export class OpenAPIGenerator {
 
     // Generate default namespace operations in main file
     const defaultOperations = namespacedOperations['default'] || [];
+    if (defaultOperations.length > 0) {
+      // Default ops live on the main client and return AxiosResponse
+      const axiosImport = mainFile.getImportDeclarations().find(d =>
+        d.getModuleSpecifierValue() === 'axios' && d.isTypeOnly()
+      );
+      if (axiosImport && !axiosImport.getNamedImports().some(n => n.getName() === 'AxiosResponse')) {
+        axiosImport.addNamedImport('AxiosResponse');
+      }
+    }
     for (const { path, method, operation, metadata } of defaultOperations) {
       this.generateMethod(classDeclaration, path, method, operation, undefined, false, metadata);
       processedOperations++;
       this.progress.update(processedOperations, operation.operationId || `${method.toUpperCase()} ${path}`);
+    }
+
+    // Import schema types referenced by default-namespace methods on the main client
+    if (defaultOperations.length > 0) {
+      this.addSchemaTypeImportsForClient(mainFile, classDeclaration);
     }
 
     // Generate separate files for each namespace
@@ -2803,10 +2836,7 @@ ${operations.map(({ operationId }) => {
       ? path.replace(pathParamRegex, (match, paramName) => {
           const normalizedParamName = this.naming.toPropertyName(paramName);
           if (pathParamsSet.has(normalizedParamName)) {
-            // Use bracket notation for quoted property names, dot notation otherwise
-            const accessor = normalizedParamName.startsWith("'") || normalizedParamName.startsWith('"')
-              ? `params[${normalizedParamName}]`
-              : `params.${normalizedParamName}`;
+            const accessor = this.naming.toPropertyAccessor('params', normalizedParamName, false);
             return `\${${accessor}}`;
           }
           return match;
@@ -2835,8 +2865,7 @@ ${operations.map(({ operationId }) => {
         const queryParamsList = queryParams.map(p => {
           const param = paramMap.get(p);
           const isRequired = param?.required;
-          // OPTIMIZATION: Compute accessor once instead of in template string
-          const accessor = (paramsIsOptional || !isRequired) ? `params?.${p}` : `params.${p}`;
+          const accessor = this.naming.toPropertyAccessor('params', p, paramsIsOptional || !isRequired);
           return `${p}: ${accessor}`;
         }).join(', ');
         statements.push(`const queryParams = { ${queryParamsList} };`);
@@ -2847,8 +2876,7 @@ ${operations.map(({ operationId }) => {
         const headerParamsList = headerParams.map(p => {
           const param = paramMap.get(p);
           const isRequired = param?.required;
-          // OPTIMIZATION: Compute accessor once instead of in template string
-          const accessor = (paramsIsOptional || !isRequired) ? `params?.${p}` : `params.${p}`;
+          const accessor = this.naming.toPropertyAccessor('params', p, paramsIsOptional || !isRequired);
           return `${p}: ${accessor}`;
         }).join(', ');
         statements.push(`const headers = { ${headerParamsList} };`);
@@ -3494,5 +3522,60 @@ ${operations.map(({ operationId }) => {
     }
     
     return usedTypes;
+  }
+
+  /**
+   * Adds type-only imports for schema types referenced by methods on a client file.
+   * Skips locally generated aliases (Params/Data/Response) and the client class name.
+   */
+  private addSchemaTypeImportsForClient(file: SourceFile, classDeclaration: any): void {
+    const usedTypes = this.extractUsedTypesFromClassMethods(classDeclaration);
+    if (usedTypes.size === 0) {
+      return;
+    }
+
+    const allSchemas = (this.api?.components as any)?.schemas || (this.api as any)?.definitions || {};
+    const localTypeNames = new Set(file.getTypeAliases().map(t => t.getName()));
+    const clientClassName = `${this.namespace}Client`;
+    const importedTypes = new Set<string>();
+
+    for (const typeName of usedTypes) {
+      if (localTypeNames.has(typeName) || typeName === clientClassName) {
+        continue;
+      }
+
+      const schemaName = Object.keys(allSchemas).find(
+        name => this.naming.toTypeName(name) === typeName
+      );
+      if (schemaName) {
+        importedTypes.add(typeName);
+      }
+    }
+
+    if (importedTypes.size === 0) {
+      return;
+    }
+
+    const existingImport = file.getImportDeclarations().find(d =>
+      d.getModuleSpecifierValue() === './types.js'
+    );
+
+    if (existingImport) {
+      const alreadyImported = new Set(existingImport.getNamedImports().map(n => n.getName()));
+      for (const typeName of Array.from(importedTypes).sort()) {
+        if (!alreadyImported.has(typeName)) {
+          existingImport.addNamedImport(typeName);
+        }
+      }
+      if (!existingImport.isTypeOnly()) {
+        existingImport.setIsTypeOnly(true);
+      }
+    } else {
+      file.addImportDeclaration({
+        moduleSpecifier: './types.js',
+        namedImports: Array.from(importedTypes).sort(),
+        isTypeOnly: true,
+      });
+    }
   }
 }

--- a/src/utils/naming.ts
+++ b/src/utils/naming.ts
@@ -58,12 +58,26 @@ export class NamingUtils {
     if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(unquotedName)) {
       result = unquotedName;
     } else {
-      result = `'${unquotedName}'`;
+      // Escape embedded single quotes so generated identifiers stay valid
+      result = `'${unquotedName.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
     }
     
     // Cache the result
     this.propertyNameCache.set(name, result);
     return result;
+  }
+
+  /**
+   * Builds a TypeScript property accessor expression.
+   * Uses bracket notation for quoted/invalid identifiers (e.g. params['x-api-key']).
+   */
+  toPropertyAccessor(objectName: string, propertyName: string, optional = false): string {
+    const prop = this.toPropertyName(propertyName);
+    const isQuoted = prop.startsWith("'") || prop.startsWith('"');
+    if (isQuoted) {
+      return optional ? `${objectName}?.[${prop}]` : `${objectName}[${prop}]`;
+    }
+    return optional ? `${objectName}?.${prop}` : `${objectName}.${prop}`;
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix invalid TypeScript accessors for hyphenated query/header params (`params['x-api-key']` instead of `params.'x-api-key'`)
- Import `AxiosResponse` and referenced schema types on the main client for default-namespace operations
- Emit `export {}` in empty `types.ts` so `export * from './types.js'` type-checks
- Resolve relative redirect locations (and cap redirect loops) when fetching remote specs
- Escape embedded quotes in property names / `const` values and quote invalid discriminator property names

## Test plan
- [x] `bun run test` (204 tests passing)
- [x] Regression coverage for hyphenated params (including `tsc` on generated client)
- [x] Regression coverage for main-client type/`AxiosResponse` imports
- [x] Regression coverage for empty `types.ts` module export
- [x] Relative redirect fetch coverage via local HTTP server

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7c2a-bf5c-7dc9-ac13-1fa297537a43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7c2a-bf5c-7dc9-ac13-1fa297537a43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

